### PR TITLE
Fix error in README file for environment creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the repo for our CS 197 final project.
 After cloning the directory, please run:
 
 ```
-conda env create --file requirements.txt
+conda create --name <env> --file requirements.txt
 ```
 
 If adding packages to the directory, please update the `requirements.txt`:


### PR DESCRIPTION
There previously had been an error with the command that creates the new environment in the README file.