### PR TITLE
Multigpu training support

### DIFF
--- a/masked-autoencoders/.gitignore
+++ b/masked-autoencoders/.gitignore
@@ -1,0 +1,1 @@
+output_dir*/

--- a/masked-autoencoders/PRETRAIN.md
+++ b/masked-autoencoders/PRETRAIN.md
@@ -55,3 +55,13 @@ python main_pretrain.py
 ```
 
 And we are training a masked autoencoder!
+
+### Multi-GPU Training
+
+We do a lot of our training on multiple GPUs on a single node (e.g. AWS p3.8xlarge instances). If you have multiple GPUs on your machine, you can use the `multigpu_pretrain.py` training script we developed. You can just run:
+
+```
+torchrun multigpu_pretrain.py --world_size=[# of gpus on node]
+```
+
+and you are now training using all the GPUs! You can confirm with the single GPU case that this runs a lot faster.

--- a/masked-autoencoders/main_pretrain.py
+++ b/masked-autoencoders/main_pretrain.py
@@ -74,11 +74,13 @@ def get_args_parser():
                         help='epochs to warmup LR')
 
     # Dataset parameters
+    curr_time = datetime.datetime.now().strftime("%m-%d-%Y-%H-%M-%S")
+    default_output_dir = f'./output_dir_{curr_time}'
     parser.add_argument('--data_path', default='../../CheXzero/cxr_data/files/', type=str,
                         help='dataset path')
-    parser.add_argument('--output_dir', default='./output_dir',
+    parser.add_argument('--output_dir', default=default_output_dir,
                         help='path where to save, empty for no saving')
-    parser.add_argument('--log_dir', default='./output_dir',
+    parser.add_argument('--log_dir', default=default_output_dir,
                         help='path where to tensorboard log')
     parser.add_argument('--device', default='cuda',
                         help='device to use for training / testing')

--- a/masked-autoencoders/main_pretrain.py
+++ b/masked-autoencoders/main_pretrain.py
@@ -194,6 +194,11 @@ def main(args):
 
     misc.load_model(args=args, model_without_ddp=model_without_ddp, optimizer=optimizer, loss_scaler=loss_scaler)
 
+    if args.output_dir:
+        misc.save_model(
+            args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
+            loss_scaler=loss_scaler, epoch="initialization")
+
     print(f"Start training for {args.epochs} epochs")
     start_time = time.time()
     for epoch in range(args.start_epoch, args.epochs):

--- a/masked-autoencoders/main_pretrain.py
+++ b/masked-autoencoders/main_pretrain.py
@@ -44,7 +44,7 @@ def get_args_parser():
                         help='Accumulate gradient iterations (for increasing the effective batch size under memory constraints)')
 
     # Model parameters
-    parser.add_argument('--model', default='mae_vit_large_patch16', type=str, metavar='MODEL',
+    parser.add_argument('--model', default='mae_vit_base_patch16', type=str, metavar='MODEL',
                         help='Name of model to train')
 
     parser.add_argument('--input_size', default=224, type=int,

--- a/masked-autoencoders/main_pretrain.py
+++ b/masked-autoencoders/main_pretrain.py
@@ -205,7 +205,7 @@ def main(args):
             log_writer=log_writer,
             args=args
         )
-        if args.output_dir and (epoch % 20 == 0 or epoch + 1 == args.epochs):
+        if args.output_dir:
             misc.save_model(
                 args=args, model=model, model_without_ddp=model_without_ddp, optimizer=optimizer,
                 loss_scaler=loss_scaler, epoch=epoch)

--- a/masked-autoencoders/multigpu_pretrain.py
+++ b/masked-autoencoders/multigpu_pretrain.py
@@ -1,0 +1,20 @@
+import os
+from pathlib import Path
+
+import torch.multiprocessing as mp
+
+from main_pretrain import get_args_parser, main
+
+def multigpu_main(rank, args):
+    os.environ["RANK"] = str(rank)
+    os.environ['LOCAL_RANK'] = str(rank)
+    main(args)
+
+if __name__ == "__main__":
+    args = get_args_parser()
+    args = args.parse_args()
+    if args.output_dir:
+        Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    print(f"Training with {args.world_size} GPUs")
+    os.environ['WORLD_SIZE'] = str(args.world_size)
+    mp.spawn(multigpu_main, args=(args,), nprocs=args.world_size)


### PR DESCRIPTION
Previous code could only run multi-gpu training on a SLURM cluster, this adds a python script to support multi-gpu training on a single node. We provide instructions on how to use the multigpu_pretrain.py script in PRETRAIN.md.